### PR TITLE
feat: 초대 api 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,0 @@
-<!-- BEGIN:nextjs-agent-rules -->
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
-<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/src/apis/common/type.d.ts
+++ b/src/apis/common/type.d.ts
@@ -1,0 +1,10 @@
+export interface UserSummary {
+  id: number;
+  nickname: string;
+  email: string;
+}
+
+export interface DashboardSummary {
+  id: number;
+  title: string;
+}

--- a/src/apis/dashboard-invitations/type.d.ts
+++ b/src/apis/dashboard-invitations/type.d.ts
@@ -1,35 +1,23 @@
+import { UserSummary, DashboardSummary } from "@/src/apis/common/type";
+
 export interface CreateDashboardInvitationRequest {
   email: string;
-}
-
-export interface UserSummary {
-  id: number;
-  nickname: string;
-  email: string;
-}
-
-export interface DashboardSummary {
-  id: number;
-  title: string;
 }
 
 export interface DashboardInvitationResponse {
   id: number;
   teamId: string;
-
   inviter: UserSummary;
   invitee: UserSummary;
   dashboard: DashboardSummary;
-
   inviteAccepted: boolean;
-
   createdAt: string;
   updatedAt: string;
 }
 
 export interface DashboardInvitationListResponse {
   totalCount: number;
-  invitations: DashboardInvitation[];
+  invitations: DashboardInvitationResponse[];
 }
 
 export interface GetInvitationListRequest {

--- a/src/apis/invitations/index.ts
+++ b/src/apis/invitations/index.ts
@@ -1,0 +1,24 @@
+import instance from "@/src/apis/instance";
+import {
+  GetInvitationListRequest,
+  GetInvitationListResponse,
+  UpdateInvitationRequest,
+  Invitation,
+} from "@/src/apis/invitations/type";
+
+export const invitationsApi = {
+  update: async (invitationId: number, body: UpdateInvitationRequest) => {
+    const { data } = await instance.put<Invitation>(
+      `/invitations/${invitationId}`,
+      body,
+    );
+    return data;
+  },
+  getList: async (params?: GetInvitationListRequest) => {
+    const { data } = await instance.get<GetInvitationListResponse>(
+      "/invitations",
+      { params },
+    );
+    return data;
+  },
+};

--- a/src/apis/invitations/type.d.ts
+++ b/src/apis/invitations/type.d.ts
@@ -1,0 +1,42 @@
+export interface Inviter {
+  nickname: string;
+  email: string;
+  id: number;
+}
+
+export interface Invitee {
+  nickname: string;
+  email: string;
+  id: number;
+}
+
+export interface InvitationDashboard {
+  title: string;
+  id: number;
+}
+
+export interface Invitation {
+  id: number;
+  inviter: Inviter;
+  teamId: string;
+  dashboard: InvitationDashboard;
+  invitee: Invitee;
+  inviteAccepted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateInvitationRequest {
+  inviteAccepted: boolean;
+}
+
+export interface GetInvitationListRequest {
+  size?: number;
+  cursorId?: number;
+  title?: string;
+}
+
+export interface GetInvitationListResponse {
+  cursorId: number;
+  invitations: Invitation[];
+}

--- a/src/apis/invitations/type.d.ts
+++ b/src/apis/invitations/type.d.ts
@@ -37,6 +37,6 @@ export interface GetInvitationListRequest {
 }
 
 export interface GetInvitationListResponse {
-  cursorId: number;
+  cursorId: number | null;
   invitations: Invitation[];
 }

--- a/src/apis/invitations/type.d.ts
+++ b/src/apis/invitations/type.d.ts
@@ -1,26 +1,11 @@
-export interface Inviter {
-  nickname: string;
-  email: string;
-  id: number;
-}
-
-export interface Invitee {
-  nickname: string;
-  email: string;
-  id: number;
-}
-
-export interface InvitationDashboard {
-  title: string;
-  id: number;
-}
+import { UserSummary, DashboardSummary } from "@/src/apis/common/type";
 
 export interface Invitation {
   id: number;
-  inviter: Inviter;
+  inviter: UserSummary;
   teamId: string;
-  dashboard: InvitationDashboard;
-  invitee: Invitee;
+  dashboard: DashboardSummary;
+  invitee: UserSummary;
   inviteAccepted: boolean;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 작업 내용
- 내가 받은 초대 목록 조회 api 개발
- 초대 응답 api 개발

## 관련된 이슈
- closes #7 

## 리뷰 요청 사항(선택)
대시보드에 있는 초대관련 api 들을 이 파일에서 관리하는건 별로일까요?
목적이 달라서 좀 꺼려지긴하는데 다른분들 생각이 궁금합니다