### PR TITLE
feat: 대시보드 생성 모달 개발

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,11 +1,19 @@
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance } from 'axios';
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   timeout: 5000,
 });
 
-// instance.interceptors.request.use();
-// instance.interceptors.response.use();
+instance.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('accessToken');
+    // 액세스토큰 관리 로직 머지되면 변경
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
 
 export default instance;

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -93,7 +93,11 @@ export default function DashboardCreateModal({
           <button type="button" onClick={onClose}>
             취소
           </button>
-          <button type="button" onClick={handleCreate}>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={!title.trim() || !color}
+          >
             생성
           </button>
         </div>

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -2,10 +2,13 @@
 import { useState } from 'react';
 import Modal from '../../Modal';
 import { dashboardsApi } from '@/src/apis/dashboards';
+import * as S from './style';
 import type {
   DashboardCreateModalProps,
   DashboardCreateModalState,
 } from './type';
+
+const COLORS = ['#7AC555', '#760DDE', '#FF8832', '#76A5EA'];
 
 export default function DashboardCreateModal({
   onClose,
@@ -28,17 +31,72 @@ export default function DashboardCreateModal({
   return (
     // input button 공통 컴포넌트 개발시 대체
     <Modal onClose={onClose}>
-      <div>
-        <h1>대시보드 만들기</h1>
-        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      <S.Container>
+        <S.Header>
+          <S.Title>새 대시보드 생성</S.Title>
+          <S.CloseButton type="button" aria-label="모달 닫기">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <path
+                d="M19.5459 17.954C19.7572 18.1653 19.876 18.452 19.876 18.7509C19.876 19.0497 19.7572 19.3364 19.5459 19.5477C19.3346 19.7591 19.0479 19.8778 18.749 19.8778C18.4501 19.8778 18.1635 19.7591 17.9521 19.5477L12 13.5937L6.0459 19.5459C5.83455 19.7572 5.54791 19.8759 5.24902 19.8759C4.95014 19.8759 4.66349 19.7572 4.45215 19.5459C4.2408 19.3345 4.12207 19.0479 4.12207 18.749C4.12207 18.4501 4.2408 18.1635 4.45215 17.9521L10.4062 11.9999L4.45402 6.04586C4.24268 5.83451 4.12395 5.54787 4.12395 5.24898C4.12395 4.9501 4.24268 4.66345 4.45402 4.45211C4.66537 4.24076 4.95201 4.12203 5.2509 4.12203C5.54978 4.12203 5.83643 4.24076 6.04777 4.45211L12 10.4062L17.954 4.45117C18.1654 4.23983 18.452 4.12109 18.7509 4.12109C19.0498 4.12109 19.3364 4.23983 19.5478 4.45117C19.7591 4.66251 19.8778 4.94916 19.8778 5.24804C19.8778 5.54693 19.7591 5.83358 19.5478 6.04492L13.5937 11.9999L19.5459 17.954Z"
+                fill="#333236"
+              />
+            </svg>
+          </S.CloseButton>
+        </S.Header>
+
+        <S.Label>대시보드 이름</S.Label>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="새로운 대시보드"
+        />
+
+        <S.ColorSection>
+          {COLORS.map((eachColor) => (
+            <S.ColorCircle
+              key={eachColor}
+              type="button"
+              $bgColor={eachColor}
+              $selected={color === eachColor}
+              onClick={() => setColor(eachColor)}
+              aria-label={`색상 선택: ${eachColor}`}
+            >
+              {color === eachColor && (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <path
+                    d="M20 6L9 17L4 12"
+                    stroke="#fff"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </S.ColorCircle>
+          ))}
+        </S.ColorSection>
+
         <div>
-          <div onClick={() => setColor('#7AC555')}>색깔 선택 버튼</div>
-          <div onClick={() => setColor('#760DDE')}>색깔 선택 버튼</div>
-          <div onClick={() => setColor('#FF8832')}>색깔 선택 버튼</div>
-          <div onClick={() => setColor('#76A5EA')}>색깔 선택 버튼</div>
+          <button type="button" onClick={onClose}>
+            취소
+          </button>
+          <button type="button" onClick={handleCreate}>
+            생성
+          </button>
         </div>
-        <button onClick={handleCreate}>생성</button>
-      </div>
+      </S.Container>
     </Modal>
   );
 }

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -30,10 +30,10 @@ export default function DashboardCreateModal({
 
   return (
     // input button 공통 컴포넌트 개발시 대체
-    <Modal onClose={onClose}>
+    <Modal onClose={onClose} labelledById="dashboard-create-modal-title">
       <S.Container>
         <S.Header>
-          <S.Title>새 대시보드 생성</S.Title>
+          <S.Title id="dashboard-create-modal-title">새 대시보드 생성</S.Title>
           <S.CloseButton type="button" aria-label="모달 닫기" onClick={onClose}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -50,8 +50,9 @@ export default function DashboardCreateModal({
           </S.CloseButton>
         </S.Header>
 
-        <S.Label>대시보드 이름</S.Label>
+        <S.Label htmlFor="dashboard-title">대시보드 이름</S.Label>
         <input
+          id="dashboard-title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="새로운 대시보드"

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useState } from 'react';
+import Modal from '../../Modal';
+import { dashboardsApi } from '@/src/apis/dashboards';
+import type {
+  DashboardCreateModalProps,
+  DashboardCreateModalState,
+} from './type';
+
+export default function DashboardCreateModal({
+  onClose,
+}: DashboardCreateModalProps) {
+  const [title, setTitle] = useState<DashboardCreateModalState['title']>('');
+  const [color, setColor] = useState<DashboardCreateModalState['color']>('');
+
+  const handleCreate = async () => {
+    try {
+      await dashboardsApi.create({ title, color });
+      alert('대시보드가 생성되었습니다.');
+      // Toast 개발 완료시 Toast 로 대체
+      onClose();
+    } catch (error) {
+      console.error(error);
+      // 공통 에러 인터셉터 개발 후 삭제
+    }
+  };
+
+  return (
+    // input button 공통 컴포넌트 개발시 대체
+    <Modal onClose={onClose}>
+      <div>
+        <h1>대시보드 만들기</h1>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+        <div>
+          <div onClick={() => setColor('#7AC555')}>색깔 선택 버튼</div>
+          <div onClick={() => setColor('#760DDE')}>색깔 선택 버튼</div>
+          <div onClick={() => setColor('#FF8832')}>색깔 선택 버튼</div>
+          <div onClick={() => setColor('#76A5EA')}>색깔 선택 버튼</div>
+        </div>
+        <button onClick={handleCreate}>생성</button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -34,7 +34,7 @@ export default function DashboardCreateModal({
       <S.Container>
         <S.Header>
           <S.Title>새 대시보드 생성</S.Title>
-          <S.CloseButton type="button" aria-label="모달 닫기">
+          <S.CloseButton type="button" aria-label="모달 닫기" onClick={onClose}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"

--- a/src/components/modals/DashboardCreateModal/style.ts
+++ b/src/components/modals/DashboardCreateModal/style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 30px;
+  max-width: 480px;
+  min-width: 320px;
+  width: 100%;
+  background: #fff;
+  border-radius: 16px;
+`;

--- a/src/components/modals/DashboardCreateModal/style.ts
+++ b/src/components/modals/DashboardCreateModal/style.ts
@@ -1,10 +1,64 @@
 import styled from 'styled-components';
 
+// 컬러팔레트 머지되면 색상값 변경
+
 export const Container = styled.div`
-  padding: 30px;
-  max-width: 480px;
+  padding: 28px;
+  max-width: 584px;
   min-width: 320px;
   width: 100%;
-  background: #fff;
+  background: #f3f5f8;
   border-radius: 16px;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;
+
+export const Title = styled.h2`
+  font-size: 20px;
+  font-weight: 700;
+  color: #333236;
+`;
+
+export const CloseButton = styled.button`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Label = styled.label`
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333236;
+  margin-bottom: 10px;
+`;
+
+export const ColorSection = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 24px;
+`;
+
+export const ColorCircle = styled.button<{
+  $bgColor: string;
+  $selected: boolean;
+}>`
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background-color: ${({ $bgColor }) => $bgColor};
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: ${({ $selected }) => ($selected ? 1 : 0.6)};
 `;

--- a/src/components/modals/DashboardCreateModal/type.ts
+++ b/src/components/modals/DashboardCreateModal/type.ts
@@ -1,0 +1,8 @@
+export interface DashboardCreateModalProps {
+  onClose: () => void;
+}
+
+export interface DashboardCreateModalState {
+  title: string;
+  color: string;
+}


### PR DESCRIPTION
## 작업 내용
- Axios request 인터셉터 추가: localStorage에서 액세스토큰 읽어 Authorization 헤더에 자동 주입
- 대시보드 생성 모달 기능 구현: 이름 입력, 색상 선택, 생성 API 연결(dashboardsApi.create)
- 대시보드 생성 모달 퍼블리싱: 컨테이너, 헤더, 색상 선택 UI (input, button, 색상값은 공통 컴포넌트 개발 후 대체 예정)

## 관련된 이슈
#33 (추후 퍼블리싱 완료시 close) 
closes #34

## 스크린샷(선택)

## 리뷰 요청 사항(선택)
- input, button은 공통 컴포넌트 개발 완료 후 대체 예정입니다.
- 색상값은 디자인 확정 후 업데이트 예정입니다.
- 성공 alert는 Toast 컴포넌트 개발 후 대체 예정입니다.
- 인터셉터에 존재하는 액세스 토큰 받아오는 부분은 추후에 다은님 피알 머지되면 고쳐서 다시 올리겠습니다