### PR TITLE
feat: FAQ 페이지 구현

### DIFF
--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import * as S from './styles';
+
+const faqList = [
+  {
+    question: '커뮤니티는 어떻게 만들 수 있나요?',
+    answer:
+      '로그인 후 나의 대시보드 페이지에서 새로운 대시보드를 생성 후, 대시보드 수정하기 페이지에서 구성원을 초대할 수 있습니다.',
+  },
+  {
+    question: '멤버 초대는 어떤 방식으로 진행되나요?',
+    answer:
+      '로그인 후 나의 대시보드 페이지에서 새로운 대시보드를 생성 후, 대시보드 수정하기 페이지에서 이메일 기반 초대를 통해 멤버를 추가할 수 있습니다.',
+  },
+  {
+    question: '일정 카드는 어떤 정보까지 공유할 수 있나요?',
+    answer:
+      '일정 제목, 설명, 마감일, 담당자, 태그, 이미지를 카드 형태로 등록할 수 있고 커뮤니티 내 멤버가 동일한 카드 내용을 함께 확인할 수 있습니다.',
+  },
+  {
+    question: '할 일 목록은 어떤 기준으로 분류가 가능한가요?',
+    answer: 'Taskify는 대시보드 내 칼럼을 통해 일정을 분류할 수 있습니다.',
+  },
+  {
+    question: '댓글 기능은 어떤 상황에서 유용한가요?',
+    answer:
+      '해당 할 일 카드별 진행 상황 공유, 요청사항 기록, 피드백 정리에 활용할 수 있어 커뮤니티 내 의사소통을 한 곳에서 관리하기 좋습니다.',
+  },
+  {
+    question: '실수로 삭제한 할 일을 복구할 수 있나요?',
+    answer:
+      '현재 버전에서는 즉시 복구 기능을 지원하지 않으므로, 삭제 전 모달에서 확인이 필요합니다.',
+  },
+  {
+    question: 'Taskify는 어떤 기기에서 사용할 수 있나요?',
+    answer:
+      'Taskify는 웹 기반 서비스이기 때문에 PC, 테블릿 모바일 브라우저에서 모두 이용할 수 있으며, 반응형 UI로 주요 기능을 동일하게 사용할 수 있습니다.',
+  },
+] as const;
+
+export default function FaqPage() {
+  const [openQuestions, setOpenQuestions] = useState<string[]>([]);
+
+  const handleToggle = (question: string) => {
+    setOpenQuestions((prev) =>
+      prev.includes(question)
+        ? prev.filter((openQuestion) => openQuestion !== question)
+        : [...prev, question]
+    );
+  };
+
+  return (
+    <S.Main>
+      <S.Content>
+        <S.HomeLink href="/" aria-label="메인 페이지로 이동">
+          <Image src="/images/icon-logo.svg" alt="Taskify 로고" fill priority />
+        </S.HomeLink>
+        <S.Title>자주 묻는 질문</S.Title>
+        <S.Description>
+          Taskify 이용 중 자주 질문하는 내용을 모았습니다.
+        </S.Description>
+
+        <S.ListSection>
+          {faqList.map((faq, index) => (
+            <S.Item key={faq.question}>
+              <S.ToggleButton
+                type="button"
+                onClick={() => handleToggle(faq.question)}
+                aria-expanded={openQuestions.includes(faq.question)}
+                aria-controls={`faq-answer-${index}`}
+              >
+                <S.QuestionTitle>
+                  <S.LeftToggleIcon aria-hidden="true">
+                    {openQuestions.includes(faq.question) ? '▾' : '▸'}
+                  </S.LeftToggleIcon>
+                  {faq.question}
+                </S.QuestionTitle>
+                <S.RightToggleIcon>
+                  {openQuestions.includes(faq.question) ? '−' : '+'}
+                </S.RightToggleIcon>
+              </S.ToggleButton>
+              {openQuestions.includes(faq.question) && (
+                <S.Answer id={`faq-answer-${index}`}>{faq.answer}</S.Answer>
+              )}
+            </S.Item>
+          ))}
+        </S.ListSection>
+      </S.Content>
+    </S.Main>
+  );
+}

--- a/src/app/(public)/faq/styles.ts
+++ b/src/app/(public)/faq/styles.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import Link from 'next/link';
+import styled from 'styled-components';
+
+export const Main = styled.main`
+  min-height: 100vh;
+  padding: 56px 20px 72px;
+`;
+
+export const Content = styled.div`
+  max-width: 860px;
+  margin: 0 auto;
+`;
+
+export const HomeLink = styled(Link)`
+  display: inline-block;
+  width: 180px;
+  height: 40px;
+  position: relative;
+`;
+
+export const Title = styled.h1`
+  margin-top: 16px;
+  margin-bottom: 12px;
+  font-size: 36px;
+  color: #333236;
+`;
+
+export const Description = styled.p`
+  margin-bottom: 28px;
+  color: #6b6674;
+`;
+
+export const ListSection = styled.section`
+  display: grid;
+  gap: 14px;
+`;
+
+export const Item = styled.article`
+  background-color: #ffffff;
+  border: 1px solid #ebe9f4;
+  border-radius: 12px;
+  padding: 20px;
+`;
+
+export const ToggleButton = styled.button`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+`;
+
+export const QuestionTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 0;
+  color: #333236;
+`;
+
+export const LeftToggleIcon = styled.span`
+  color: #83c6e5;
+  font-size: 18px;
+  line-height: 1;
+`;
+
+export const RightToggleIcon = styled.span`
+  font-size: 20px;
+  color: #83c6e5;
+`;
+
+export const Answer = styled.p`
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid #ebe9f4;
+  line-height: 1.6;
+  color: #4b4654;
+`;


### PR DESCRIPTION
## 작업 내용
- /(public)/faq 경로에 FAQ 페이지 추가
- 자주 묻는 질문 및 답변 구성
- 질문 클릭 시 답변이 열리고 닫히는 토글로 동작 구현
- 단일 오픈 방식에서 여러 질문 동시 오픈 가능하도록 상태 로직 확장
   - 질문 제목 앞에 토글 기호(▸/▾) 추가해서 토글 기능 시각화
- 상단 이동 링크를 텍스트 대신 로고 클릭 시 메인 페이지(/) 이동으로 변경

## 관련된 이슈
- #79 

## 스크린샷(선택)
- PC
<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/098e40db-db7f-4cf7-bcb6-770d28b54906" />

-Tablet
<img width="1120" height="800" alt="image" src="https://github.com/user-attachments/assets/7df3e052-9f76-4782-a038-fe39b3ca4639" />

- Mobile
<img width="588" height="795" alt="image" src="https://github.com/user-attachments/assets/796edfb6-5684-46c6-a4aa-e38ad81653a2" />


## 리뷰 요청 사항(선택)
- 현재 페이지에서 반응형 우선순위가 낮아보여 별도로 구현하지 않았습니다.