### PR TITLE
fix: 토큰 키 accessToken으로 통일 및 instance 토큰 참조 방식 변경

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { getAccessToken } from '@/src/utils/authTokenStorage';
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -6,12 +7,9 @@ const instance: AxiosInstance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('accessToken');
-    // 액세스토큰 관리 로직 머지되면 변경
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+  const token = getAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });

--- a/src/utils/authTokenStorage.ts
+++ b/src/utils/authTokenStorage.ts
@@ -1,23 +1,11 @@
-const ACCESS_TOKEN_KEY = 'taskify:accessToken';
-const LEGACY_ACCESS_TOKEN_KEY = 'accessToken';
+const ACCESS_TOKEN_KEY = 'accessToken';
 
 export const getAccessToken = (): string | null => {
   if (typeof window === 'undefined') {
     return null;
   }
 
-  const currentToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-  if (currentToken) {
-    return currentToken;
-  }
-
-  const legacyToken = localStorage.getItem(LEGACY_ACCESS_TOKEN_KEY);
-  if (legacyToken) {
-    localStorage.setItem(ACCESS_TOKEN_KEY, legacyToken);
-    localStorage.removeItem(LEGACY_ACCESS_TOKEN_KEY);
-  }
-
-  return legacyToken;
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
 };
 
 export const setAccessToken = (accessToken: string) => {
@@ -34,5 +22,4 @@ export const removeAccessToken = () => {
   }
 
   localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(LEGACY_ACCESS_TOKEN_KEY);
 };


### PR DESCRIPTION
## 작업 내용
- authTokenStorage.ts의 토큰 키를 taskify:accessToken → accessToken으로 통일
- LEGACY_ACCESS_TOKEN_KEY 제거
- instance.ts에서 localStorage.getItem('accessToken') 하드코딩 제거 후 getAccessToken() 유틸로 교체


## 관련된 이슈
- 

## 스크린샷(선택)

## 리뷰 요청 사항(선택)