### PR TITLE
feat: 로그인 페이지 1차 배포 문제점 해결

### DIFF
--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -62,8 +62,8 @@ export default function FaqPage() {
   return (
     <S.Main>
       <S.Content>
-        <S.HomeLink href="/" aria-label="메인 페이지로 이동">
-          <Image src="/images/icon-logo.svg" alt="Taskify 로고" fill priority />
+        <S.HomeLink href='/' aria-label='메인 페이지로 이동'>
+          <Image src='/images/icon-logo.svg' alt='Taskify 로고' fill priority />
         </S.HomeLink>
         <S.Title>자주 묻는 질문</S.Title>
         <S.Description>
@@ -75,13 +75,13 @@ export default function FaqPage() {
             <S.Item key={faq.id}>
               <S.QuestionTitle>
                 <S.ToggleButton
-                  type="button"
+                  type='button'
                   onClick={() => handleToggle(faq.id)}
                   aria-expanded={openQuestions.includes(faq.id)}
                   aria-controls={`faq-answer-${index}`}
                 >
                   <S.QuestionText>
-                    <S.LeftToggleIcon aria-hidden="true">
+                    <S.LeftToggleIcon aria-hidden='true'>
                       {openQuestions.includes(faq.id) ? '▾' : '▸'}
                     </S.LeftToggleIcon>
                     {faq.question}

--- a/src/app/(public)/login/constants.ts
+++ b/src/app/(public)/login/constants.ts
@@ -1,0 +1,13 @@
+import { AUTH_VALIDATION_MESSAGES } from '@/src/utils/authValidation';
+
+export const ERROR_MESSAGES = {
+  emailRequired: '이메일을 입력해 주세요.',
+  emailInvalid: AUTH_VALIDATION_MESSAGES.emailInvalid,
+  passwordRequired: '비밀번호를 입력해 주세요.',
+  passwordInvalid: AUTH_VALIDATION_MESSAGES.passwordInvalid,
+  loginFailed: '이메일 또는 비밀번호를 확인해 주세요.',
+  userNotFound: '가입된 이메일이 아닙니다.',
+  network: '네트워크 오류가 발생했어요.',
+  temporary: '일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.',
+  unknown: '알 수 없는 오류가 발생했어요.',
+} as const;

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -6,6 +6,11 @@ import { FormEvent, useState } from 'react';
 import axios from 'axios';
 import { postLogin } from '@/src/apis/auth';
 import { setAccessToken } from '@/src/utils/authTokenStorage';
+import {
+  AUTH_VALIDATION_MESSAGES,
+  isValidEmail,
+  isValidPassword,
+} from '@/src/utils/authValidation';
 import * as S from './styles';
 import Link from 'next/link';
 
@@ -15,22 +20,17 @@ type FormErrors = {
   common?: string;
 };
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MIN_PASSWORD_LENGTH = 8;
 const ERROR_MESSAGES = {
   emailRequired: '이메일을 입력해 주세요.',
-  email: '이메일 형식이 올바르지 않아요.',
+  email: AUTH_VALIDATION_MESSAGES.emailInvalid,
   passwordRequired: '비밀번호를 입력해 주세요.',
-  password: `비밀번호를 ${MIN_PASSWORD_LENGTH}자 이상 작성해 주세요.`,
+  password: AUTH_VALIDATION_MESSAGES.passwordInvalid,
   loginFailed: '이메일 또는 비밀번호를 확인해 주세요.',
   userNotFound: '가입된 이메일이 아닙니다.',
   network: '네트워크 오류가 발생했어요.',
   temporary: '일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.',
   unknown: '알 수 없는 오류가 발생했어요.',
 } as const;
-
-const isValidEmail = (value: string) => EMAIL_REGEX.test(value);
-const isValidPassword = (value: string) => value.length >= MIN_PASSWORD_LENGTH;
 
 export default function LoginPage() {
   const router = useRouter();

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,158 +1,40 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { FormEvent, useState } from 'react';
-import axios from 'axios';
-import { postLogin } from '@/src/apis/auth';
-import { setAccessToken } from '@/src/utils/authTokenStorage';
-import {
-  AUTH_VALIDATION_MESSAGES,
-  isValidEmail,
-  isValidPassword,
-} from '../../../utils/authValidation';
-import * as S from './styles';
 import Link from 'next/link';
-
-type FormErrors = {
-  email?: string;
-  password?: string;
-  common?: string;
-};
-
-const ERROR_MESSAGES = {
-  emailRequired: '이메일을 입력해 주세요.',
-  email: AUTH_VALIDATION_MESSAGES.emailInvalid,
-  passwordRequired: '비밀번호를 입력해 주세요.',
-  password: AUTH_VALIDATION_MESSAGES.passwordInvalid,
-  loginFailed: '이메일 또는 비밀번호를 확인해 주세요.',
-  userNotFound: '가입된 이메일이 아닙니다.',
-  network: '네트워크 오류가 발생했어요.',
-  temporary: '일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.',
-  unknown: '알 수 없는 오류가 발생했어요.',
-} as const;
+import { FormEvent } from 'react';
+import { useLoginForm } from '@/src/hooks/useLoginForm';
+import { useLoginSubmit } from '@/src/hooks/useLoginSubmit';
+import * as S from './styles';
 
 export default function LoginPage() {
-  const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [emailTouched, setEmailTouched] = useState(false);
-  const [passwordTouched, setPasswordTouched] = useState(false);
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [errors, setErrors] = useState<FormErrors>({});
-  const [isLoading, setIsLoading] = useState(false);
+  const {
+    email,
+    password,
+    errors,
+    isPasswordVisible,
+    setIsPasswordVisible,
+    setErrors,
+    setCommonError,
+    handleEmailChange,
+    handlePasswordChange,
+    handleEmailBlur,
+    handlePasswordBlur,
+    validate,
+  } = useLoginForm();
+  const { isLoading, submitLogin } = useLoginSubmit();
   const isLoginButtonDisabled =
     isLoading || email.trim().length === 0 || password.trim().length === 0;
 
-  const handleEmailBlur = () => {
-    setEmailTouched(true);
-    setErrors((prev) => ({
-      ...prev,
-      email:
-        email.trim().length === 0
-          ? ERROR_MESSAGES.emailRequired
-          : isValidEmail(email)
-            ? undefined
-            : ERROR_MESSAGES.email,
-    }));
-  };
-
-  const handlePasswordBlur = () => {
-    setPasswordTouched(true);
-    setErrors((prev) => ({
-      ...prev,
-      password:
-        password.length === 0
-          ? ERROR_MESSAGES.passwordRequired
-          : isValidPassword(password)
-            ? undefined
-            : ERROR_MESSAGES.password,
-    }));
-  };
-
-  // 이메일 및 비밀번호 형식 정규식 검사
-  const validate = () => {
-    const nextErrors: FormErrors = {};
-
-    if (email.trim().length === 0) {
-      nextErrors.email = ERROR_MESSAGES.emailRequired;
-    } else if (!isValidEmail(email)) {
-      nextErrors.email = ERROR_MESSAGES.email;
-    }
-
-    if (password.length === 0) {
-      nextErrors.password = ERROR_MESSAGES.passwordRequired;
-    } else if (!isValidPassword(password)) {
-      nextErrors.password = ERROR_MESSAGES.password;
-    }
-
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setErrors({});
-
-    if (!validate()) {
-      return;
-    }
-
-    try {
-      setIsLoading(true);
-
-      const data = await postLogin({ email, password });
-      setAccessToken(data.accessToken);
-
-      router.replace('/');
-      router.push('/mydashboard');
-    } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        if (error.code === 'ECONNABORTED' || !error.response) {
-          setErrors({ common: ERROR_MESSAGES.network });
-          return;
-        }
-
-        const status = error.response?.status;
-        const errorMessage =
-          typeof error.response?.data === 'object' &&
-          error.response?.data !== null &&
-          'message' in error.response.data &&
-          typeof error.response.data.message === 'string'
-            ? error.response.data.message
-            : '';
-
-        if (status === 404) {
-          setErrors({
-            email: ERROR_MESSAGES.userNotFound,
-          });
-          return;
-        }
-
-        if (status === 400 || status === 401 || status === 403) {
-          setErrors({
-            password: ERROR_MESSAGES.loginFailed,
-          });
-          return;
-        }
-
-        if (typeof status === 'number' && status >= 400 && status < 500) {
-          setErrors({
-            common: errorMessage || ERROR_MESSAGES.temporary,
-          });
-          return;
-        }
-
-        setErrors({
-          common: ERROR_MESSAGES.temporary,
-        });
-        return;
-      }
-
-      setErrors({ common: ERROR_MESSAGES.unknown });
-    } finally {
-      setIsLoading(false);
-    }
+    await submitLogin({
+      email,
+      password,
+      validate,
+      setErrors,
+      setCommonError,
+    });
   };
 
   return (
@@ -177,22 +59,7 @@ export default function LoginPage() {
             type='email'
             $hasError={Boolean(errors.email)}
             value={email}
-            onChange={(e) => {
-              const nextEmail = e.target.value;
-              setEmail(nextEmail);
-
-              if (emailTouched) {
-                setErrors((prev) => ({
-                  ...prev,
-                  email:
-                    nextEmail.trim().length === 0
-                      ? ERROR_MESSAGES.emailRequired
-                      : isValidEmail(nextEmail)
-                        ? undefined
-                        : ERROR_MESSAGES.email,
-                }));
-              }
-            }}
+            onChange={(e) => handleEmailChange(e.target.value)}
             onBlur={handleEmailBlur}
             placeholder='이메일을 입력해주세요'
           />
@@ -206,22 +73,7 @@ export default function LoginPage() {
               type={isPasswordVisible ? 'text' : 'password'}
               $hasError={Boolean(errors.password)}
               value={password}
-              onChange={(e) => {
-                const nextPassword = e.target.value;
-                setPassword(nextPassword);
-
-                if (passwordTouched) {
-                  setErrors((prev) => ({
-                    ...prev,
-                    password:
-                      nextPassword.length === 0
-                        ? ERROR_MESSAGES.passwordRequired
-                        : isValidPassword(nextPassword)
-                          ? undefined
-                          : ERROR_MESSAGES.password,
-                  }));
-                }
-              }}
+              onChange={(e) => handlePasswordChange(e.target.value)}
               onBlur={handlePasswordBlur}
               placeholder='비밀번호를 입력해주세요'
             />

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -10,7 +10,7 @@ import {
   AUTH_VALIDATION_MESSAGES,
   isValidEmail,
   isValidPassword,
-} from '@/src/utils/authValidation';
+} from '../../../utils/authValidation';
 import * as S from './styles';
 import Link from 'next/link';
 
@@ -158,11 +158,11 @@ export default function LoginPage() {
   return (
     <S.Container>
       <S.FormSection>
-        <Link href="/" aria-label="메인 페이지 이동">
+        <Link href='/' aria-label='메인 페이지 이동'>
           <S.LogoWrapper>
             <Image
-              src="/images/icon-logo.svg"
-              alt="Taskify 로고"
+              src='/images/icon-logo.svg'
+              alt='Taskify 로고'
               fill
               priority
             />
@@ -170,11 +170,11 @@ export default function LoginPage() {
         </Link>
 
         <S.LoginForm onSubmit={handleSubmit}>
-          <S.Label htmlFor="email">이메일</S.Label>
+          <S.Label htmlFor='email'>이메일</S.Label>
           {/* 인풋 공통 컴포넌트 사용 예정 */}
           <S.TextInput
-            id="email"
-            type="email"
+            id='email'
+            type='email'
             $hasError={Boolean(errors.email)}
             value={email}
             onChange={(e) => {
@@ -194,15 +194,15 @@ export default function LoginPage() {
               }
             }}
             onBlur={handleEmailBlur}
-            placeholder="이메일을 입력해주세요"
+            placeholder='이메일을 입력해주세요'
           />
           <S.ErrorText>{errors.email || ' '}</S.ErrorText>
 
-          <S.Label htmlFor="password">비밀번호</S.Label>
+          <S.Label htmlFor='password'>비밀번호</S.Label>
           <S.PasswordField>
             {/* 인풋 공통 컴포넌트 사용 예정 */}
             <S.PasswordInput
-              id="password"
+              id='password'
               type={isPasswordVisible ? 'text' : 'password'}
               $hasError={Boolean(errors.password)}
               value={password}
@@ -223,11 +223,11 @@ export default function LoginPage() {
                 }
               }}
               onBlur={handlePasswordBlur}
-              placeholder="비밀번호를 입력해주세요"
+              placeholder='비밀번호를 입력해주세요'
             />
             {/* 눈 아이콘 클릭 시 비밀번호 보기/숨기기 */}
             <S.TogglePasswordButton
-              type="button"
+              type='button'
               onClick={() => setIsPasswordVisible((prev) => !prev)}
               aria-label={
                 isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'
@@ -239,7 +239,7 @@ export default function LoginPage() {
                     ? '/images/password-eye-on.svg'
                     : '/images/password-eye-off.svg'
                 }
-                alt=""
+                alt=''
                 width={20}
                 height={20}
               />
@@ -250,14 +250,14 @@ export default function LoginPage() {
           {errors.common && <S.ErrorText>{errors.common}</S.ErrorText>}
 
           {/* 버튼 공통 컴포넌트 사용 예정 */}
-          <S.LoginButton type="submit" disabled={isLoginButtonDisabled}>
+          <S.LoginButton type='submit' disabled={isLoginButtonDisabled}>
             {isLoading ? '로그인 중' : '로그인'}
           </S.LoginButton>
         </S.LoginForm>
 
         <S.SignupRow>
           <S.HelperText>아직 회원이 아니신가요?</S.HelperText>
-          <S.SignupLink href="/signup">회원가입하기</S.SignupLink>
+          <S.SignupLink href='/signup'>회원가입하기</S.SignupLink>
         </S.SignupRow>
       </S.FormSection>
     </S.Container>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -18,7 +18,9 @@ type FormErrors = {
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MIN_PASSWORD_LENGTH = 8;
 const ERROR_MESSAGES = {
+  emailRequired: '이메일을 입력해 주세요.',
   email: '이메일 형식이 올바르지 않아요.',
+  passwordRequired: '비밀번호를 입력해 주세요.',
   password: `비밀번호를 ${MIN_PASSWORD_LENGTH}자 이상 작성해 주세요.`,
   loginFailed: '이메일 또는 비밀번호를 확인해 주세요.',
   userNotFound: '가입된 이메일이 아닙니다.',
@@ -46,7 +48,12 @@ export default function LoginPage() {
     setEmailTouched(true);
     setErrors((prev) => ({
       ...prev,
-      email: isValidEmail(email) ? undefined : ERROR_MESSAGES.email,
+      email:
+        email.trim().length === 0
+          ? ERROR_MESSAGES.emailRequired
+          : isValidEmail(email)
+            ? undefined
+            : ERROR_MESSAGES.email,
     }));
   };
 
@@ -54,7 +61,12 @@ export default function LoginPage() {
     setPasswordTouched(true);
     setErrors((prev) => ({
       ...prev,
-      password: isValidPassword(password) ? undefined : ERROR_MESSAGES.password,
+      password:
+        password.length === 0
+          ? ERROR_MESSAGES.passwordRequired
+          : isValidPassword(password)
+            ? undefined
+            : ERROR_MESSAGES.password,
     }));
   };
 
@@ -62,11 +74,15 @@ export default function LoginPage() {
   const validate = () => {
     const nextErrors: FormErrors = {};
 
-    if (!isValidEmail(email)) {
+    if (email.trim().length === 0) {
+      nextErrors.email = ERROR_MESSAGES.emailRequired;
+    } else if (!isValidEmail(email)) {
       nextErrors.email = ERROR_MESSAGES.email;
     }
 
-    if (!isValidPassword(password)) {
+    if (password.length === 0) {
+      nextErrors.password = ERROR_MESSAGES.passwordRequired;
+    } else if (!isValidPassword(password)) {
       nextErrors.password = ERROR_MESSAGES.password;
     }
 
@@ -88,6 +104,7 @@ export default function LoginPage() {
       const data = await postLogin({ email, password });
       setAccessToken(data.accessToken);
 
+      router.replace('/');
       router.push('/mydashboard');
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
@@ -167,16 +184,19 @@ export default function LoginPage() {
               if (emailTouched) {
                 setErrors((prev) => ({
                   ...prev,
-                  email: isValidEmail(nextEmail)
-                    ? undefined
-                    : ERROR_MESSAGES.email,
+                  email:
+                    nextEmail.trim().length === 0
+                      ? ERROR_MESSAGES.emailRequired
+                      : isValidEmail(nextEmail)
+                        ? undefined
+                        : ERROR_MESSAGES.email,
                 }));
               }
             }}
             onBlur={handleEmailBlur}
             placeholder="이메일을 입력해주세요"
           />
-          {errors.email && <S.ErrorText>{errors.email}</S.ErrorText>}
+          <S.ErrorText>{errors.email || ' '}</S.ErrorText>
 
           <S.Label htmlFor="password">비밀번호</S.Label>
           <S.PasswordField>
@@ -193,9 +213,12 @@ export default function LoginPage() {
                 if (passwordTouched) {
                   setErrors((prev) => ({
                     ...prev,
-                    password: isValidPassword(nextPassword)
-                      ? undefined
-                      : ERROR_MESSAGES.password,
+                    password:
+                      nextPassword.length === 0
+                        ? ERROR_MESSAGES.passwordRequired
+                        : isValidPassword(nextPassword)
+                          ? undefined
+                          : ERROR_MESSAGES.password,
                   }));
                 }
               }}
@@ -222,7 +245,7 @@ export default function LoginPage() {
               />
             </S.TogglePasswordButton>
           </S.PasswordField>
-          {errors.password && <S.ErrorText>{errors.password}</S.ErrorText>}
+          <S.ErrorText>{errors.password || ' '}</S.ErrorText>
 
           {errors.common && <S.ErrorText>{errors.common}</S.ErrorText>}
 
@@ -237,15 +260,6 @@ export default function LoginPage() {
           <S.SignupLink href="/signup">회원가입하기</S.SignupLink>
         </S.SignupRow>
       </S.FormSection>
-
-      <S.DesktopImageWrapper>
-        <Image
-          src="/images/login-pc-img.png"
-          alt="Taskify 미리보기 이미지"
-          fill
-          priority
-        />
-      </S.DesktopImageWrapper>
     </S.Container>
   );
 }

--- a/src/app/(public)/login/styles.ts
+++ b/src/app/(public)/login/styles.ts
@@ -1,18 +1,16 @@
-import styled from "styled-components";
-import { DEVICE } from "@/src/styles/Breakpoints";
-import Link from "next/link";
+import styled from 'styled-components';
+import { DEVICE } from '@/src/styles/Breakpoints';
+import Link from 'next/link';
 
-// AppShell 분리 후 로그인 페이지 레이아웃 재조정 예정
 export const Container = styled.main`
   width: 100%;
-  max-width: 1440px;
+  max-width: 372px;
   min-height: 100vh;
   margin: 0 auto;
-  padding: 72px 48px;
+  padding: 72px 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(48px, 8vw, 120px);
 
   @media ${DEVICE.tablet} {
     padding: 80px 16px;
@@ -99,6 +97,8 @@ export const LoginButton = styled.button`
 `;
 
 export const ErrorText = styled.p`
+  min-height: 18px;
+  margin: 0;
   color: #e5484d;
   font-size: 13px;
 `;
@@ -121,16 +121,4 @@ export const SignupLink = styled(Link)`
   font-weight: 700;
   cursor: pointer;
   text-decoration: underline;
-`;
-
-export const DesktopImageWrapper = styled.div`
-  position: relative;
-  width: clamp(520px, 52vw, 860px);
-  aspect-ratio: 860 / 575;
-  border-radius: 12px;
-  overflow: hidden;
-
-  @media ${DEVICE.tablet} {
-    display: none;
-  }
 `;

--- a/src/app/(public)/login/utils.ts
+++ b/src/app/(public)/login/utils.ts
@@ -1,0 +1,18 @@
+import { ERROR_MESSAGES } from './constants';
+import { isValidEmail, isValidPassword } from '@/src/utils/authValidation';
+
+export const getEmailError = (email: string): string | undefined => {
+  if (email.trim().length === 0) {
+    return ERROR_MESSAGES.emailRequired;
+  }
+
+  return isValidEmail(email) ? undefined : ERROR_MESSAGES.emailInvalid;
+};
+
+export const getPasswordError = (password: string): string | undefined => {
+  if (password.length === 0) {
+    return ERROR_MESSAGES.passwordRequired;
+  }
+
+  return isValidPassword(password) ? undefined : ERROR_MESSAGES.passwordInvalid;
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,11 @@ import GlobalStyle from '@/src/styles/GlobalStyle';
 export const metadata: Metadata = {
   title: 'Taskify',
   description: 'Task management application',
+  icons: {
+    icon: '/images/favicon.svg',
+    shortcut: '/images/favicon.svg',
+    apple: '/images/favicon.svg',
+  },
 };
 
 export default function RootLayout({

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { getEmailError, getPasswordError } from '@/src/app/(public)/login/utils';
+
+export type FormErrors = {
+  email?: string;
+  password?: string;
+  common?: string;
+};
+
+export function useLoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const setCommonError = (message?: string) => {
+    setErrors((prev) => ({ ...prev, common: message }));
+  };
+
+  const handleEmailChange = (nextEmail: string) => {
+    setEmail(nextEmail);
+    if (emailTouched) {
+      setErrors((prev) => ({ ...prev, email: getEmailError(nextEmail) }));
+    }
+  };
+
+  const handlePasswordChange = (nextPassword: string) => {
+    setPassword(nextPassword);
+    if (passwordTouched) {
+      setErrors((prev) => ({ ...prev, password: getPasswordError(nextPassword) }));
+    }
+  };
+
+  const handleEmailBlur = () => {
+    setEmailTouched(true);
+    setErrors((prev) => ({ ...prev, email: getEmailError(email) }));
+  };
+
+  const handlePasswordBlur = () => {
+    setPasswordTouched(true);
+    setErrors((prev) => ({ ...prev, password: getPasswordError(password) }));
+  };
+
+  const validate = () => {
+    const nextErrors: FormErrors = {};
+    const emailError = getEmailError(email);
+    const passwordError = getPasswordError(password);
+
+    if (emailError) nextErrors.email = emailError;
+    if (passwordError) nextErrors.password = passwordError;
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  return {
+    email,
+    password,
+    errors,
+    isPasswordVisible,
+    setIsPasswordVisible,
+    setErrors,
+    setCommonError,
+    handleEmailChange,
+    handlePasswordChange,
+    handleEmailBlur,
+    handlePasswordBlur,
+    validate,
+  };
+}

--- a/src/hooks/useLoginSubmit.ts
+++ b/src/hooks/useLoginSubmit.ts
@@ -1,0 +1,81 @@
+import { useRouter } from 'next/navigation';
+import { type Dispatch, type SetStateAction, useState } from 'react';
+import axios from 'axios';
+import { postLogin } from '@/src/apis/auth';
+import { setAccessToken } from '@/src/utils/authTokenStorage';
+import { ERROR_MESSAGES } from '@/src/app/(public)/login/constants';
+import type { FormErrors } from './useLoginForm';
+
+type LoginParams = {
+  email: string;
+  password: string;
+  validate: () => boolean;
+  setErrors: Dispatch<SetStateAction<FormErrors>>;
+  setCommonError: (message?: string) => void;
+};
+
+export function useLoginSubmit() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const submitLogin = async ({
+    email,
+    password,
+    validate,
+    setErrors,
+    setCommonError,
+  }: LoginParams) => {
+    if (!validate()) {
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setCommonError(undefined);
+
+      const data = await postLogin({ email, password });
+      setAccessToken(data.accessToken);
+      router.replace('/mydashboard');
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        if (error.code === 'ECONNABORTED' || !error.response) {
+          setCommonError(ERROR_MESSAGES.network);
+          return;
+        }
+
+        const status = error.response?.status;
+        const errorMessage =
+          typeof error.response?.data === 'object' &&
+          error.response?.data !== null &&
+          'message' in error.response.data &&
+          typeof error.response.data.message === 'string'
+            ? error.response.data.message
+            : '';
+
+        if (status === 404) {
+          setErrors((prev) => ({ ...prev, email: ERROR_MESSAGES.userNotFound }));
+          return;
+        }
+
+        if (status === 400 || status === 401 || status === 403) {
+          setErrors((prev) => ({ ...prev, password: ERROR_MESSAGES.loginFailed }));
+          return;
+        }
+
+        if (typeof status === 'number' && status >= 400 && status < 500) {
+          setCommonError(errorMessage || ERROR_MESSAGES.temporary);
+          return;
+        }
+
+        setCommonError(ERROR_MESSAGES.temporary);
+        return;
+      }
+
+      setCommonError(ERROR_MESSAGES.unknown);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, submitLogin };
+}


### PR DESCRIPTION
## 작업 내용
- 금일 진행된 1차 배포 중 로그인 페이지 관련 문제점을 해결했습니다.
- `/mydashborde`에서 뒤로가기 버튼 클릭 시 `/login`으로 이동하는 문제 해결
- 인풋 태그 에러 메시지 추가됐을 때와 동일하게 간격 재구현
- 로그인 PC 버전 해상도 깨짐 이슈로 인한 사진 제거
- 파비콘 실제 배포 사이트에서 적용시킴

## 관련된 이슈
- 

## 스크린샷(선택)
- PC
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/d276cd81-2299-458a-985b-5d84882e3485" />


## 리뷰 요청 사항(선택)
- utils 폴더에 로그인과 비밀번호 페이지 공통 유틸을 추가 후 적용해놓았습니다.