### PR TITLE
refactor: API 클라이언트를 객체형에서 함수 단위로 분리

### DIFF
--- a/src/apis/cards/index.ts
+++ b/src/apis/cards/index.ts
@@ -1,36 +1,36 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
-	CreateCardRequest,
-	UpdateCardRequest,
-	Card,
-	GetCardListRequest,
-	GetCardListResponse,
-} from "@/src/apis/cards/type";
+  CreateCardRequest,
+  UpdateCardRequest,
+  Card,
+  GetCardListRequest,
+  GetCardListResponse,
+} from '@/src/apis/cards/type';
 
 export const cardsApi = {
-	create: async (body: CreateCardRequest) => {
-		const { data } = await instance.post<Card>("/cards", body);
-		return data;
-	},
+  create: async (body: CreateCardRequest) => {
+    const { data } = await instance.post<Card>('/cards', body);
+    return data;
+  },
 
-	getList: async (params: GetCardListRequest) => {
-		const { data } = await instance.get<GetCardListResponse>("/cards", {
-			params,
-		});
-		return data;
-	},
+  getList: async (params: GetCardListRequest) => {
+    const { data } = await instance.get<GetCardListResponse>('/cards', {
+      params,
+    });
+    return data;
+  },
 
-	update: async (cardId: number, body: UpdateCardRequest) => {
-		const { data } = await instance.put<Card>(`/cards/${cardId}`, body);
-		return data;
-	},
+  update: async (cardId: number, body: UpdateCardRequest) => {
+    const { data } = await instance.put<Card>(`/cards/${cardId}`, body);
+    return data;
+  },
 
-	getById: async (cardId: number) => {
-		const { data } = await instance.get<Card>(`/cards/${cardId}`);
-		return data;
-	},
+  getById: async (cardId: number) => {
+    const { data } = await instance.get<Card>(`/cards/${cardId}`);
+    return data;
+  },
 
-	remove: async (cardId: number) => {
-		await instance.delete(`/cards/${cardId}`);
-	},
+  remove: async (cardId: number) => {
+    await instance.delete(`/cards/${cardId}`);
+  },
 };

--- a/src/apis/columns/index.ts
+++ b/src/apis/columns/index.ts
@@ -1,15 +1,15 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
   CreateColumnRequest,
   UpdateColumnRequest,
   Column,
   GetColumnListResponse,
   UploadCardImageResponse,
-} from "@/src/apis/columns/type";
+} from '@/src/apis/columns/type';
 
 export const columnsApi = {
   create: async (body: CreateColumnRequest) => {
-    const { data } = await instance.post<Column>("/columns", body);
+    const { data } = await instance.post<Column>('/columns', body);
     return data;
   },
   update: async (columnId: number, body: UpdateColumnRequest) => {
@@ -18,10 +18,10 @@ export const columnsApi = {
   },
   uploadCardImage: async (columnId: number, image: File) => {
     const formData = new FormData();
-    formData.append("image", image);
+    formData.append('image', image);
     const { data } = await instance.post<UploadCardImageResponse>(
       `/columns/${columnId}/card-image`,
-      formData,
+      formData
     );
     return data;
   },

--- a/src/apis/comments/index.ts
+++ b/src/apis/comments/index.ts
@@ -1,37 +1,32 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
-	CreateCommentRequest,
-	UpdateCommentRequest,
-	Comment,
-	GetCommentListRequest,
-	GetCommentListResponse,
-} from "@/src/apis/comments/type";
+  CreateCommentRequest,
+  UpdateCommentRequest,
+  Comment,
+  GetCommentListRequest,
+  GetCommentListResponse,
+} from '@/src/apis/comments/type';
 
-export const commentsApi = {
-	create: async (body: CreateCommentRequest) => {
-		const { data } = await instance.post<Comment>("/comments", body);
-		return data;
-	},
+export const createComment = async (body: CreateCommentRequest) => {
+  const { data } = await instance.post<Comment>('/comments', body);
+  return data;
+};
 
-	getList: async (params: GetCommentListRequest) => {
-		const { data } = await instance.get<GetCommentListResponse>(
-			"/comments",
-			{
-				params,
-			},
-		);
-		return data;
-	},
+export const getCommentList = async (params: GetCommentListRequest) => {
+  const { data } = await instance.get<GetCommentListResponse>('/comments', {
+    params,
+  });
+  return data;
+};
 
-	update: async (commentId: number, body: UpdateCommentRequest) => {
-		const { data } = await instance.put<Comment>(
-			`/comments/${commentId}`,
-			body,
-		);
-		return data;
-	},
+export const updateComment = async (
+  commentId: number,
+  body: UpdateCommentRequest
+) => {
+  const { data } = await instance.put<Comment>(`/comments/${commentId}`, body);
+  return data;
+};
 
-	remove: async (commentId: number) => {
-		await instance.delete(`/comments/${commentId}`);
-	},
+export const removeComment = async (commentId: number) => {
+  await instance.delete(`/comments/${commentId}`);
 };

--- a/src/apis/dashboard-invitations/index.ts
+++ b/src/apis/dashboard-invitations/index.ts
@@ -17,7 +17,7 @@ export const createDashboardInvitation = async (
   return data;
 };
 
-export const getDashboardInviatationList = async (
+export const getDashboardInvitationList = async (
   dashboardId: number,
   params: GetInvitationListRequest
 ) => {

--- a/src/apis/dashboard-invitations/index.ts
+++ b/src/apis/dashboard-invitations/index.ts
@@ -1,39 +1,43 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
   CreateDashboardInvitationRequest,
   DashboardInvitationListResponse,
   DashboardInvitationResponse,
   GetInvitationListRequest,
-} from "@/src/apis/dashboard-invitations/type";
+} from '@/src/apis/dashboard-invitations/type';
 
-export const dashboardInvitationsApi = {
-  create: async (
-    dashboardId: number,
-    body: CreateDashboardInvitationRequest,
-  ) => {
-    const { data } = await instance.post<DashboardInvitationResponse>(
-      `/dashboards/${dashboardId}/invitations`,
-      body,
-    );
-    return data;
-  },
+export const createDashboardInvitation = async (
+  dashboardId: number,
+  body: CreateDashboardInvitationRequest
+) => {
+  const { data } = await instance.post<DashboardInvitationResponse>(
+    `/dashboards/${dashboardId}/invitations`,
+    body
+  );
+  return data;
+};
 
-  getList: async (dashboardId: number, params: GetInvitationListRequest) => {
-    const { data } = await instance.get<DashboardInvitationListResponse>(
-      `/dashboards/${dashboardId}/invitations`,
-      {
-        params: {
-          navigationMethod: "infiniteScroll",
-          ...params,
-        },
+export const getDashboardInviatationList = async (
+  dashboardId: number,
+  params: GetInvitationListRequest
+) => {
+  const { data } = await instance.get<DashboardInvitationListResponse>(
+    `/dashboards/${dashboardId}/invitations`,
+    {
+      params: {
+        navigationMethod: 'infiniteScroll',
+        ...params,
       },
-    );
-    return data;
-  },
+    }
+  );
+  return data;
+};
 
-  cancel: async (dashboardId: number, invitationId: number) => {
-    await instance.delete(
-      `/dashboards/${dashboardId}/invitations/${invitationId}`,
-    );
-  },
+export const cancelDashboardInvitation = async (
+  dashboardId: number,
+  invitationId: number
+) => {
+  await instance.delete(
+    `/dashboards/${dashboardId}/invitations/${invitationId}`
+  );
 };

--- a/src/apis/dashboards/index.ts
+++ b/src/apis/dashboards/index.ts
@@ -7,41 +7,37 @@ import {
   UpdateDashboardRequest,
 } from '@/src/apis/dashboards/type';
 
-export const dashboardsApi = {
-  create: async (body: CreateDashboardRequest) => {
-    const { data } = await instance.post<Dashboard>('/dashboards', body);
-    return data;
-  },
+export const createDashboard = async (body: CreateDashboardRequest) => {
+  const { data } = await instance.post<Dashboard>('/dashboards', body);
+  return data;
+};
 
-  getById: async (dashboardId: number) => {
-    const { data } = await instance.get<Dashboard>(
-      `/dashboards/${dashboardId}`
-    );
-    return data;
-  },
+export const getDashboardById = async (dashboardId: number) => {
+  const { data } = await instance.get<Dashboard>(`/dashboards/${dashboardId}`);
+  return data;
+};
 
-  getList: async (params: GetDashboardListRequest) => {
-    const { data } = await instance.get<GetDashboardListResponse>(
-      '/dashboards',
-      {
-        params: {
-          navigationMethod: 'infiniteScroll',
-          ...params,
-        },
-      }
-    );
-    return data;
-  },
+export const getDashboardList = async (params: GetDashboardListRequest) => {
+  const { data } = await instance.get<GetDashboardListResponse>('/dashboards', {
+    params: {
+      navigationMethod: 'infiniteScroll',
+      ...params,
+    },
+  });
+  return data;
+};
 
-  update: async (dashboardId: number, body: UpdateDashboardRequest) => {
-    const { data } = await instance.put<Dashboard>(
-      `/dashboards/${dashboardId}`,
-      body
-    );
-    return data;
-  },
+export const updateDashboard = async (
+  dashboardId: number,
+  body: UpdateDashboardRequest
+) => {
+  const { data } = await instance.put<Dashboard>(
+    `/dashboards/${dashboardId}`,
+    body
+  );
+  return data;
+};
 
-  remove: async (dashboardId: number) => {
-    await instance.delete(`/dashboards/${dashboardId}`);
-  },
+export const removeDashboard = async (dashboardId: number) => {
+  await instance.delete(`/dashboards/${dashboardId}`);
 };

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -4,9 +4,6 @@ import { getAccessToken } from '@/src/utils/authTokenStorage';
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   timeout: 5000,
-  headers: {
-    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NjcwNSwidGVhbUlkIjoiMjMtNCIsImlhdCI6MTc3NzQyNjM0MywiaXNzIjoic3AtdGFza2lmeSJ9.6CRZmL1iPf_aEChAKcoHTAdeK-b0d-37H6lt54y9Cms`,
-  },
 });
 
 instance.interceptors.request.use((config) => {

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -4,6 +4,9 @@ import { getAccessToken } from '@/src/utils/authTokenStorage';
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   timeout: 5000,
+  headers: {
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NjcwNSwidGVhbUlkIjoiMjMtNCIsImlhdCI6MTc3NzQyNjM0MywiaXNzIjoic3AtdGFza2lmeSJ9.6CRZmL1iPf_aEChAKcoHTAdeK-b0d-37H6lt54y9Cms`,
+  },
 });
 
 instance.interceptors.request.use((config) => {

--- a/src/apis/invitations/index.ts
+++ b/src/apis/invitations/index.ts
@@ -1,24 +1,26 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
   GetInvitationListRequest,
   GetInvitationListResponse,
   UpdateInvitationRequest,
   Invitation,
-} from "@/src/apis/invitations/type";
+} from '@/src/apis/invitations/type';
 
-export const invitationsApi = {
-  update: async (invitationId: number, body: UpdateInvitationRequest) => {
-    const { data } = await instance.put<Invitation>(
-      `/invitations/${invitationId}`,
-      body,
-    );
-    return data;
-  },
-  getList: async (params?: GetInvitationListRequest) => {
-    const { data } = await instance.get<GetInvitationListResponse>(
-      "/invitations",
-      { params },
-    );
-    return data;
-  },
+export const updateInvitation = async (
+  invitationId: number,
+  body: UpdateInvitationRequest
+) => {
+  const { data } = await instance.put<Invitation>(
+    `/invitations/${invitationId}`,
+    body
+  );
+  return data;
+};
+
+export const getInvitationList = async (params?: GetInvitationListRequest) => {
+  const { data } = await instance.get<GetInvitationListResponse>(
+    '/invitations',
+    { params }
+  );
+  return data;
 };

--- a/src/apis/members/index.ts
+++ b/src/apis/members/index.ts
@@ -1,9 +1,9 @@
-import instance from "@/src/apis/instance";
-import { GetMemberListResponse } from "@/src/apis/members/type";
+import instance from '@/src/apis/instance';
+import { GetMemberListResponse } from '@/src/apis/members/type';
 
 export const membersApi = {
   getList: async (dashboardId: number, page?: number, size?: number) => {
-    const { data } = await instance.get<GetMemberListResponse>("/members", {
+    const { data } = await instance.get<GetMemberListResponse>('/members', {
       params: { dashboardId, page, size },
     });
     return data;

--- a/src/apis/users/index.ts
+++ b/src/apis/users/index.ts
@@ -1,34 +1,34 @@
-import instance from "@/src/apis/instance";
+import instance from '@/src/apis/instance';
 import {
   SignUpRequest,
   UpdateMyInfoRequest,
   UploadProfileImageResponse,
   User,
-} from "@/src/apis/users/type";
+} from '@/src/apis/users/type';
 
 export const usersApi = {
   signUp: async (body: SignUpRequest) => {
-    const { data } = await instance.post<User>("/users", body);
+    const { data } = await instance.post<User>('/users', body);
     return data;
   },
 
   getMe: async () => {
-    const { data } = await instance.get<User>("/users/me");
+    const { data } = await instance.get<User>('/users/me');
     return data;
   },
 
   updateMe: async (body: UpdateMyInfoRequest) => {
-    const { data } = await instance.put<User>("/users/me", body);
+    const { data } = await instance.put<User>('/users/me', body);
     return data;
   },
 
   uploadMyImage: async (image: File) => {
     const formData = new FormData();
-    formData.append("image", image);
+    formData.append('image', image);
 
     const { data } = await instance.post<UploadProfileImageResponse>(
-      "/users/me/image",
-      formData,
+      '/users/me/image',
+      formData
     );
     return data;
   },

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -9,7 +9,7 @@ import CrownIcon from '@/src/components/icons/icon-crown.svg';
 import * as S from './styles';
 import type { SidebarProps } from '@/src/components/layout/Sidebar/type';
 import type { Dashboard } from '@/src/apis/dashboards/type';
-import { dashboardsApi } from '@/src/apis/dashboards';
+import { getDashboardList } from '@/src/apis/dashboards';
 
 export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const pathname = usePathname();
@@ -24,7 +24,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
       setIsError(false);
 
       try {
-        const { dashboards } = await dashboardsApi.getList({ size: 20 }); //TODO 추후 무한 스크롤 구현을 위한 임의의 size 설정
+        const { dashboards } = await getDashboardList({ size: 20 }); //TODO 추후 무한 스크롤 구현을 위한 임의의 size 설정
         setDashboards(dashboards);
       } catch (e) {
         console.error(e);

--- a/src/components/modals/DashboardCreateModal/index.tsx
+++ b/src/components/modals/DashboardCreateModal/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import Modal from '../../Modal';
-import { dashboardsApi } from '@/src/apis/dashboards';
+import { createDashboard } from '@/src/apis/dashboards';
 import * as S from './style';
 import type {
   DashboardCreateModalProps,
@@ -18,7 +18,7 @@ export default function DashboardCreateModal({
 
   const handleCreate = async () => {
     try {
-      await dashboardsApi.create({ title, color });
+      await createDashboard({ title, color });
       alert('대시보드가 생성되었습니다.');
       // Toast 개발 완료시 Toast 로 대체
       onClose();

--- a/src/components/modals/todo/TodoCardModal/index.tsx
+++ b/src/components/modals/todo/TodoCardModal/index.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import Image from 'next/image';
 import { cardsApi } from '@/src/apis/cards';
-import { commentsApi } from '@/src/apis/comments';
+import { createComment, getCommentList } from '@/src/apis/comments';
 import { usersApi } from '@/src/apis/users';
 import type { Card } from '@/src/apis/cards/type';
 import type { Comment } from '@/src/apis/comments/type';
@@ -169,7 +169,7 @@ export default function TodoCardModal({
     try {
       isSubmittingRef.current = true;
 
-      const newComment = await commentsApi.create({
+      const newComment = await createComment({
         content,
         cardId,
         columnId: card.columnId,
@@ -231,7 +231,7 @@ export default function TodoCardModal({
     try {
       setIsCommentLoading(true);
 
-      const data = await commentsApi.getList({
+      const data = await getCommentList({
         cardId,
         size: 10,
         cursorId: nextCursorId ?? undefined,


### PR DESCRIPTION
## 작업 내용
- 현재 작업중이 아닌 API의 구조를 개별 export로 수정하였습니다.
    - 현재 변경된 api : `commentApi`, `DashboardInvitationsApi`, `DashboardsApi`, `InvitationsApi`
    - 개별 작업 이후 변경 예정인 api : `cardsApi`, `columnsApi`,  `membersApi`, `usersApi`

## 백그라운드
- 최초에 제안드렸던 API 클라이언트 구조는 객체 형태입니다. 특정 함수만 사용하더라도 전체 모듈이 함께 import되는 구조였습니다. 이 구조는 번들러의 tree-shaking 최적화에 불리하게 작용할 수 있어, 사용하지 않는 코드까지 포함될 가능성이 있습니다. 이를 개선하기 위해 API를 함수 단위로 개별 export하도록 구조를 변경하였습니다.
- 해당 변경을 통해 필요한 API만 선택적으로 import할 수 있어 번들 크기 최적화와 코드 가독성 향상을 기대할 수 있습니다.

## 관련된 이슈
- Closes #90 