### PR TITLE
fix: turbopack SVG glob 패턴 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,11 +42,11 @@ const nextConfig: NextConfig = {
     return config;
   },
 
-    turbopack: {
-      rules: {
-      '.svg': {
+  turbopack: {
+    rules: {
+      '*.svg': {
         loaders: ['@svgr/webpack'],
-        as: '.js',
+        as: '*.js',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"


### PR DESCRIPTION
## 작업 내용
- 버셀 배포 환경에서 dashboard/[id] 페이지를 렌더 시키지 못하던 오류를 해결했습니다.
