### PR TITLE
feat: 로그인 페이지 버튼 컴포넌트 적용

### DIFF
--- a/src/app/(public)/login/styles.ts
+++ b/src/app/(public)/login/styles.ts
@@ -81,12 +81,11 @@ export const TogglePasswordButton = styled.button`
 `;
 
 export const LoginButton = styled(Button).attrs({
-  variant: 'primary',
   width: '100%',
   height: '44px',
 })`
   margin-top: 8px;
-  border-radius: 8px;
+  font-weight: 700;
 `;
 
 export const ErrorText = styled.p`

--- a/src/app/(public)/login/styles.ts
+++ b/src/app/(public)/login/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { DEVICE } from '@/src/styles/Breakpoints';
 import Link from 'next/link';
+import Button from '@/src/components/common/Button';
 
 export const Container = styled.main`
   width: 100%;
@@ -79,21 +80,13 @@ export const TogglePasswordButton = styled.button`
   cursor: pointer;
 `;
 
-export const LoginButton = styled.button`
-  width: 100%;
-  height: 44px;
+export const LoginButton = styled(Button).attrs({
+  variant: 'primary',
+  width: '100%',
+  height: '44px',
+})`
   margin-top: 8px;
-  border: 0;
   border-radius: 8px;
-  background-color: #83c6e5;
-  color: #ffffff;
-  font-weight: 700;
-  cursor: pointer;
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
 `;
 
 export const ErrorText = styled.p`


### PR DESCRIPTION
## 작업 내용
- 로그인 페이지 버튼 컴포넌트 적용

## 관련된 이슈
- 

## 스크린샷(선택)

## 리뷰 요청 사항(선택)
- Button primary 색상이 시안(#83C6E5`)과 달라 현재 `#80B4DA`로 적용되어 있습니다. 글로벌 스타일 및 Button primary 색상을 변경해야할 거 같습니다.
- - 인풋 컴포넌트도 구현 후 적용 예정입니다.