### PR TITLE
fix: 할일 조회 모달 오류 수정

### DIFF
--- a/src/components/modals/todo/TodoCardModal/index.tsx
+++ b/src/components/modals/todo/TodoCardModal/index.tsx
@@ -548,7 +548,16 @@ export default function TodoCardModal({
                 return (
                   <S.CommentItem key={comment.id}>
                     <S.CommentBadge $backgroundColor={commentAuthorBgColor}>
-                      {getAvatarText(comment.author.nickname)}
+                      {comment.author.profileImageUrl ? (
+                        <Image
+                          src={comment.author.profileImageUrl}
+                          alt={comment.author.nickname}
+                          fill
+                          style={{ objectFit: 'cover' }}
+                        />
+                      ) : (
+                        getAvatarText(comment.author.nickname)
+                      )}
                     </S.CommentBadge>
 
                     <S.CommentContent>

--- a/src/components/modals/todo/TodoCardModal/styles.ts
+++ b/src/components/modals/todo/TodoCardModal/styles.ts
@@ -222,6 +222,8 @@ export const Description = styled.p`
   line-height: 1.6;
   color: var(--color-black-200);
   font-weight: 500;
+
+  white-space: pre-wrap;
 `;
 
 export const Divider = styled.hr`


### PR DESCRIPTION
## 작업 내용
1. 프로필 있는 유저 프로필도 닉네임으로 노출됐던 이슈 해결했습니다.
2. 설명글 엔터처리 안됐던 이슈 해결했습니다.

## 관련된 이슈
- 

## 스크린샷(선택)

## 리뷰 요청 사항(선택)
<img width="589" height="757" alt="스크린샷 2026-05-07 오후 11 47 38" src="https://github.com/user-attachments/assets/fa8f6915-7a2e-49ab-89b7-d822fcb94073" />

